### PR TITLE
Fix  negative day

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -106,6 +106,7 @@ export default function Home() {
     }
   
     const days = differenceInDays(eventDate, currentDate);
+    if (days < 0) return "Passed";
     if (days === 0) return "Today";
     if (days === 1) return "Tomorrow";
     return `In ${days} day${days !== 1 ? "s" : ""}`;


### PR DESCRIPTION
This seems to occur due to the Jewish time of day-end being different than the secular time of day-end.